### PR TITLE
Use Python executable found by autotools in scripts.

### DIFF
--- a/engine/ibus-engine-table.in
+++ b/engine/ibus-engine-table.in
@@ -28,15 +28,15 @@ export IBUS_TABLE_LOCATION=@datarootdir@/ibus-table
 for arg in $@; do
 	case $arg in
 	--xml | -x)
-		exec python @datarootdir@/ibus-table/engine/main.py --xml;;
+		exec @PYTHON@ @datarootdir@/ibus-table/engine/main.py --xml;;
 	--help | -h)
-		exec python @datarootdir@/ibus-table/engine/main.py $@;;
+		exec @PYTHON@ @datarootdir@/ibus-table/engine/main.py $@;;
   *)
     # first running speedmeter as a daemon
-    #python @datarootdir@/ibus-table/engine/speedmeter.py -d > /dev/null
+    #@PYTHON@ @datarootdir@/ibus-table/engine/speedmeter.py -d > /dev/null
 
     # then start our IME
-    exec python @datarootdir@/ibus-table/engine/main.py $@
+    exec @PYTHON@ @datarootdir@/ibus-table/engine/main.py $@
     exit 0
 	esac
 done

--- a/engine/ibus-table-createdb.in
+++ b/engine/ibus-table-createdb.in
@@ -26,4 +26,4 @@ datarootdir=@datarootdir@
 datadir=@datadir@
 export IBUS_TABLE_DATA_DIR=@datarootdir@
 export IBUS_TABLE_BIN_PATH=@bindir@
-exec python @datarootdir@/ibus-table/engine/tabcreatedb.py $@
+exec @PYTHON@ @datarootdir@/ibus-table/engine/tabcreatedb.py $@


### PR DESCRIPTION
On my system (ArchLinux) 'python' is actually Python 3, which leads to runtime error on engine loading.
