### PR TITLE
Fix ipa-x-sampa table and phrases containing spaces in emoji-table

### DIFF
--- a/engine/tabcreatedb.py
+++ b/engine/tabcreatedb.py
@@ -125,7 +125,7 @@ def main ():
         patt_com = re.compile(r'^###.*')
         patt_blank = re.compile(r'^[ \t]*$')
         patt_conf = re.compile(r'[^\t]*=[^\t]*')
-        patt_table = re.compile(r' *([^\s]+) *\t *([^\s]+)\t *[^\s]+ *$')
+        patt_table = re.compile(r'([^\t]+)\t([^\t]+)\t([^t]+)(\t.*)?$')
         patt_gouci = re.compile(r' *[^\s]+ *\t *[^\s]+ *$')
         patt_s = re.compile(r' *([^\s]+) *\t *([\x00-\xff]{3}) *\t *[^\s]+ *$')
 


### PR DESCRIPTION
Currently there is a regular expression which filters out several
lines defining valid phrases. The emoji-table for example has phrases
containing spaces which are currently filtered out and the ipa-x-sampa
table has trailing comments which are filtered out as well.

In phrase_parser, the phrases are parsed like:

xingma, phrase, freq = unicode (l, "utf-8").strip ().split ('\t')[:3]

Therefore, it seems reasonable to change the regular expression checking
for a table line containing a phrase definition to accept every
line which has 3 columns seperated by tabs followed optionally
by more columns also separated by tabs (the optional columns are ignored,
i.e. they are just comments in the table source).

See: https://bugzilla.redhat.com/show_bug.cgi?id=856903
