### PR TITLE
missing backslash in if conditional around "only_one_last"

### DIFF
--- a/engine/table.py
+++ b/engine/table.py
@@ -574,7 +574,7 @@ class editor(object):
                             if ascii.ispunct (self._chars[0][-1].encode('ascii')) \
                                     or len (self._chars[0][:-1]) \
                                     in self.db.pkeylens \
-                                    or only_one_last
+                                    or only_one_last \
                                     or self._auto_select:
                                 # because we use [!@#$%] to denote [12345]
                                 # in py_mode, so we need to distinguish them


### PR DESCRIPTION
I got this error after installing ibus-table from the git repo:

Traceback (most recent call last):
  File "/usr/share/ibus-table/engine/main.py", line 31, in <module>
    import factory
  File "/usr/share/ibus-table/engine/factory.py", line 27, in <module>
    import table
  File "/usr/share/ibus-table/engine/table.py", line 577
    or only_one_last
                   ^
SyntaxError: invalid syntax
